### PR TITLE
fix(UVB5/6) Fix error char format requires a bytes

### DIFF
--- a/chirp/drivers/uvb5.py
+++ b/chirp/drivers/uvb5.py
@@ -209,7 +209,7 @@ def do_download(radio):
     data += (b"\x00" * 16)
     firstack = None
     for i in range(0, 0x1000, 16):
-        frame = struct.pack(">cHB", "R", i, 16)
+        frame = struct.pack(">cHB", b"R", i, 16)
         radio.pipe.write(frame)
         result = radio.pipe.read(20)
         if frame[1:4] != result[1:4]:


### PR DESCRIPTION
```
ERROR: -- Exception: --
ERROR: Traceback (most recent call last):
  File "/home/julien/Applications/chirp/chirp/drivers/uvb5.py", line 331, in sync_in
    self._mmap = do_download(self)
  File "/home/julien/Applications/chirp/chirp/drivers/uvb5.py", line 212, in do_download
    frame = struct.pack(">cHB", "R", i, 16)
struct.error: char format requires a bytes object of length 1
```